### PR TITLE
Add MUI theme with dark mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@
 1. Ensure you are using **Node.js 20**.
 2. Run `npm install` to install dependencies.
 3. Start the development server with `npm run dev`.
+
+## Theme 切換
+
+點擊右上角的太陽／月亮按鈕或按下 `Ctrl+Shift+L` 切換暗色模式。

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,20 +1,43 @@
+'use client';
+
 import '../styles/globals.css';
-import { CssBaseline } from '@mui/material';
+import { CssBaseline, ThemeProvider } from '@mui/material';
 import Navbar from '../components/Navbar';
 import Sidebar from '../components/Sidebar';
 import type { ReactNode } from 'react';
+import { useState, useEffect } from 'react';
+import { lightTheme, darkTheme } from '../src/theme';
+import { ColorModeContext } from '../src/contexts/ColorMode';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
+  const [mode, setMode] = useState<'light' | 'dark'>('light');
+  const toggleColorMode = () =>
+    setMode((prev) => (prev === 'light' ? 'dark' : 'light'));
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.shiftKey && e.code === 'KeyL') {
+        toggleColorMode();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, []);
+
   return (
     <html lang="en">
       <head />
       <body>
-        <CssBaseline />
-        <Navbar />
-        <div style={{ display: 'flex' }}>
-          <Sidebar />
-          <main style={{ flexGrow: 1 }}>{children}</main>
-        </div>
+        <ColorModeContext.Provider value={{ toggleColorMode, mode }}>
+          <ThemeProvider theme={mode === 'light' ? lightTheme : darkTheme}>
+            <CssBaseline />
+            <Navbar />
+            <div style={{ display: 'flex' }}>
+              <Sidebar />
+              <main style={{ flexGrow: 1 }}>{children}</main>
+            </div>
+          </ThemeProvider>
+        </ColorModeContext.Provider>
       </body>
     </html>
   );

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,7 +1,26 @@
+'use client';
+
+import { IconButton } from '@mui/material';
+import DarkModeIcon from '@mui/icons-material/DarkMode';
+import LightModeIcon from '@mui/icons-material/LightMode';
+import { useColorMode } from '../src/contexts/ColorMode';
+
 export default function Navbar() {
+  const { toggleColorMode, mode } = useColorMode();
   return (
-    <nav style={{ padding: '1rem', background: '#eee' }}>
+    <nav
+      style={{
+        padding: '1rem',
+        background: '#eee',
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+      }}
+    >
       Navbar
+      <IconButton onClick={toggleColorMode} color="inherit">
+        {mode === 'light' ? <DarkModeIcon /> : <LightModeIcon />}
+      </IconButton>
     </nav>
   );
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@mui/material": "^5.14.0",
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",
+    "@mui/icons-material": "^5.14.0",
     "tailwindcss": "^3.4.0",
     "postcss": "^8.4.0",
     "autoprefixer": "^10.4.0"

--- a/src/contexts/ColorMode.tsx
+++ b/src/contexts/ColorMode.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+
+export interface ColorModeContextProps {
+  toggleColorMode: () => void;
+  mode: 'light' | 'dark';
+}
+
+export const ColorModeContext = createContext<ColorModeContextProps>({
+  toggleColorMode: () => {},
+  mode: 'light',
+});
+
+export function useColorMode() {
+  return useContext(ColorModeContext);
+}

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,0 +1,26 @@
+import { createTheme } from '@mui/material/styles';
+import { grey } from '@mui/material/colors';
+
+export const lightTheme = createTheme({
+  palette: {
+    mode: 'light',
+    primary: { main: '#5B8DEF' },
+    secondary: { main: '#FF7E6B' },
+    success: { main: '#4CAF50' },
+    error: { main: '#F44336' },
+    grey,
+  },
+});
+
+export const darkTheme = createTheme({
+  palette: {
+    mode: 'dark',
+    primary: { main: '#5B8DEF' },
+    secondary: { main: '#FF7E6B' },
+    success: { main: '#4CAF50' },
+    error: { main: '#F44336' },
+    background: { default: '#121212' },
+    text: { primary: '#ffffff' },
+    grey,
+  },
+});


### PR DESCRIPTION
## Summary
- build a theme with brand colors and dark mode
- manage color mode with new context
- wrap app with ThemeProvider
- add light/dark toggle button in the navbar
- document theme switch instructions

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run typecheck` *(fails: Cannot find module '@mui/material')*

------
https://chatgpt.com/codex/tasks/task_e_687a0cf4d8d8832fb6b116533fcf9858