### PR TITLE
Apply Material UI layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,20 +1,44 @@
 import '../styles/globals.css';
-import { CssBaseline } from '@mui/material';
-import Navbar from '../components/Navbar';
-import Sidebar from '../components/Sidebar';
-import type { ReactNode } from 'react';
+import { CssBaseline, ThemeProvider, createTheme, PaletteMode, Box } from '@mui/material';
+import Navbar from '../components/layout/Navbar';
+import Sidebar, { drawerWidth } from '../components/layout/Sidebar';
+import { ReactNode, useMemo, useState } from 'react';
+import { useMediaQuery } from '@mui/material';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
+  const [mode, setMode] = useState<PaletteMode>('light');
+  const [collapsed, setCollapsed] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  const theme = useMemo(() => createTheme({ palette: { mode } }), [mode]);
+  const mdUp = useMediaQuery(theme.breakpoints.up('md'));
+
+  const toggleSidebar = () => {
+    if (mdUp) {
+      setCollapsed((c) => !c);
+    } else {
+      setMobileOpen((o) => !o);
+    }
+  };
+
+  const toggleColor = () => setMode((prev) => (prev === 'light' ? 'dark' : 'light'));
+
+  const sidebarWidth = collapsed ? 72 : drawerWidth;
+
   return (
     <html lang="en">
       <head />
       <body>
-        <CssBaseline />
-        <Navbar />
-        <div style={{ display: 'flex' }}>
-          <Sidebar />
-          <main style={{ flexGrow: 1 }}>{children}</main>
-        </div>
+        <ThemeProvider theme={theme}>
+          <CssBaseline />
+          <Box display="flex" minHeight="100vh">
+            <Navbar toggleSidebar={toggleSidebar} toggleColor={toggleColor} mode={mode} />
+            <Sidebar collapsed={collapsed} mobileOpen={mobileOpen} toggle={toggleSidebar} />
+            <Box component="main" flexGrow={1} pt={7} pl={{ xs: 0, md: sidebarWidth }}>
+              {children}
+            </Box>
+          </Box>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/app/sales/page.tsx
+++ b/app/sales/page.tsx
@@ -1,0 +1,3 @@
+export default function SalesPage() {
+  return <h1>Sales Page</h1>;
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,3 @@
+export default function SettingsPage() {
+  return <h1>Settings Page</h1>;
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,7 +1,0 @@
-export default function Navbar() {
-  return (
-    <nav style={{ padding: '1rem', background: '#eee' }}>
-      Navbar
-    </nav>
-  );
-}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,7 +1,0 @@
-export default function Sidebar() {
-  return (
-    <aside style={{ width: '200px', background: '#fafafa', padding: '1rem' }}>
-      Sidebar
-    </aside>
-  );
-}

--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -1,0 +1,32 @@
+import AppBar from '@mui/material/AppBar';
+import Toolbar from '@mui/material/Toolbar';
+import IconButton from '@mui/material/IconButton';
+import Typography from '@mui/material/Typography';
+import MenuIcon from '@mui/icons-material/Menu';
+import LightModeIcon from '@mui/icons-material/LightMode';
+import DarkModeIcon from '@mui/icons-material/DarkMode';
+import { PaletteMode } from '@mui/material';
+
+interface NavbarProps {
+  toggleSidebar: () => void;
+  toggleColor: () => void;
+  mode: PaletteMode;
+}
+
+export default function Navbar({ toggleSidebar, toggleColor, mode }: NavbarProps) {
+  return (
+    <AppBar position="fixed" elevation={0}>
+      <Toolbar>
+        <IconButton edge="start" onClick={toggleSidebar} color="inherit" sx={{ mr: 2 }}>
+          <MenuIcon />
+        </IconButton>
+        <Typography variant="h6" sx={{ flexGrow: 1 }}>
+          Dashboard
+        </Typography>
+        <IconButton onClick={toggleColor} color="inherit">
+          {mode === 'light' ? <LightModeIcon /> : <DarkModeIcon />}
+        </IconButton>
+      </Toolbar>
+    </AppBar>
+  );
+}

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -1,0 +1,90 @@
+import Drawer from '@mui/material/Drawer';
+import List from '@mui/material/List';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import DashboardIcon from '@mui/icons-material/Dashboard';
+import BarChartIcon from '@mui/icons-material/BarChart';
+import SettingsIcon from '@mui/icons-material/Settings';
+import { useTheme } from '@mui/material/styles';
+import { usePathname } from 'next/navigation';
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+
+export const drawerWidth = 240;
+
+interface NavItem {
+  title: string;
+  icon: ReactNode;
+  href: string;
+}
+
+const navItems: NavItem[] = [
+  { title: 'Dashboard', icon: <DashboardIcon />, href: '/' },
+  { title: 'Sales', icon: <BarChartIcon />, href: '/sales' },
+  { title: 'Settings', icon: <SettingsIcon />, href: '/settings' },
+];
+
+interface SidebarProps {
+  collapsed: boolean;
+  mobileOpen: boolean;
+  toggle: () => void;
+}
+
+export default function Sidebar({ collapsed, mobileOpen, toggle }: SidebarProps) {
+  const theme = useTheme();
+  const pathname = usePathname();
+
+  const width = collapsed ? 72 : drawerWidth;
+
+  const content = (
+    <List>
+      {navItems.map((item) => (
+        <Link key={item.href} href={item.href} passHref legacyBehavior>
+          <ListItemButton component="a" selected={pathname === item.href}
+            sx={{
+              pl: 2,
+            }}
+          >
+            <ListItemIcon>{item.icon}</ListItemIcon>
+            <ListItemText primary={item.title} sx={{ opacity: collapsed ? 0 : 1 }} />
+          </ListItemButton>
+        </Link>
+      ))}
+    </List>
+  );
+
+  return (
+    <>
+      <Drawer
+        variant="permanent"
+        open={!collapsed}
+        sx={{
+          display: { xs: 'none', md: 'block' },
+          width,
+          flexShrink: 0,
+          '& .MuiDrawer-paper': {
+            position: 'relative',
+            whiteSpace: 'nowrap',
+            width,
+            transition: theme.transitions.create('width'),
+          },
+        }}
+      >
+        {content}
+      </Drawer>
+      <Drawer
+        variant="temporary"
+        open={mobileOpen}
+        onClose={toggle}
+        ModalProps={{ keepMounted: true }}
+        sx={{
+          display: { xs: 'block', md: 'none' },
+          '& .MuiDrawer-paper': { width: drawerWidth },
+        }}
+      >
+        {content}
+      </Drawer>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- rebuild layout with MUI ThemeProvider and responsive sidebar
- implement `Navbar` and `Sidebar` components under layout folder
- add placeholder `sales` and `settings` pages

## Testing
- `npm config set registry https://registry.npmmirror.com` *(fails: npm not installed)*
- `npm install --ignore-scripts` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687cbd7bdb10832f94df781a6e8e81be