### PR TITLE
Add KPI cards with mock API

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@
 1. Ensure you are using **Node.js 20**.
 2. Run `npm install` to install dependencies.
 3. Start the development server with `npm run dev`.
+
+## 本地假資料 API
+
+開發環境提供 `/api/kpi` 端點回傳 KPI 假資料，可搭配 hooks 使用。

--- a/app/api/kpi/route.ts
+++ b/app/api/kpi/route.ts
@@ -1,0 +1,8 @@
+export async function GET() {
+  return Response.json({
+    revenue: 126400,
+    orders: 231,
+    traffic: 87500,
+    conversion: 2.14,
+  });
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,57 @@
+'use client';
+
+import Grid from '@mui/material/Unstable_Grid2';
+import AttachMoney from '@mui/icons-material/AttachMoney';
+import ShoppingCart from '@mui/icons-material/ShoppingCart';
+import BarChart from '@mui/icons-material/BarChart';
+import TrendingUp from '@mui/icons-material/TrendingUp';
+import useKpi from '../hooks/useKpi';
+import KpiCard from '../components/kpi/KpiCard';
+
 export default function HomePage() {
-  return <h1>Dashboard Home</h1>;
+  const { data } = useKpi();
+  return (
+    <Grid container spacing={2}>
+      {data && (
+        <>
+          <Grid xs={12} md={3}>
+            <KpiCard
+              title="Revenue"
+              value={`$${data.revenue.toLocaleString()}`}
+              diff={5.2}
+              icon={<AttachMoney />}
+              color="primary"
+            />
+          </Grid>
+          <Grid xs={12} md={3}>
+            <KpiCard
+              title="Orders"
+              value={data.orders}
+              diff={-1.3}
+              icon={<ShoppingCart />}
+              color="secondary"
+            />
+          </Grid>
+          <Grid xs={12} md={3}>
+            <KpiCard
+              title="Traffic"
+              value={data.traffic}
+              diff={3.1}
+              icon={<BarChart />}
+              color="info"
+            />
+          </Grid>
+          <Grid xs={12} md={3}>
+            <KpiCard
+              title="CVR"
+              value={`${data.conversion}%`}
+              diff={0.4}
+              icon={<TrendingUp />}
+              color="success"
+            />
+          </Grid>
+        </>
+      )}
+    </Grid>
+  );
 }

--- a/components/kpi/KpiCard.tsx
+++ b/components/kpi/KpiCard.tsx
@@ -1,0 +1,37 @@
+import { Card, CardContent, Stack, Typography } from '@mui/material';
+import { ArrowUpward, ArrowDownward } from '@mui/icons-material';
+import { ReactElement } from 'react';
+
+interface KpiCardProps {
+  title: string;
+  value: string | number;
+  diff: number;
+  icon: ReactElement;
+  color: 'primary' | 'secondary' | 'info' | 'success' | 'warning' | 'error';
+}
+
+export default function KpiCard({ title, value, diff, icon, color }: KpiCardProps) {
+  const isPositive = diff >= 0;
+  const DiffIcon = isPositive ? ArrowUpward : ArrowDownward;
+  return (
+    <Card>
+      <CardContent>
+        <Stack direction="row" alignItems="center" spacing={1}>
+          {icon}
+          <Typography color={color} variant="h6">
+            {title}
+          </Typography>
+        </Stack>
+        <Typography variant="h4" gutterBottom>
+          {value}
+        </Typography>
+        <Stack direction="row" alignItems="center" spacing={0.5}>
+          <DiffIcon style={{ color: isPositive ? 'green' : 'red' }} fontSize="small" />
+          <Typography variant="body2" style={{ color: isPositive ? 'green' : 'red' }}>
+            {Math.abs(diff)}%
+          </Typography>
+        </Stack>
+      </CardContent>
+    </Card>
+  );
+}

--- a/hooks/useKpi.ts
+++ b/hooks/useKpi.ts
@@ -1,0 +1,7 @@
+import useSWR from 'swr';
+
+const fetcher = (url: string) => fetch(url).then(res => res.json());
+
+export default function useKpi() {
+  return useSWR('/api/kpi', fetcher);
+}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "postcss": "^8.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "tailwindcss": "^3.4.0"
+    "tailwindcss": "^3.4.0",
+    "swr": "^2.2.0"
   },
   "devDependencies": {
     "@types/node": "24.0.14",


### PR DESCRIPTION
## Summary
- add mock KPI API route
- create `useKpi` hook using SWR
- build `KpiCard` component
- show KPI cards on home page
- document local mock API
- add `swr` dependency

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cd5044f00832f8cc3af5dbc94c9cc