### PR TITLE
Revamp layout with MUI components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+.DS_Store

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,20 +1,39 @@
+'use client';
 import '../styles/globals.css';
-import { CssBaseline } from '@mui/material';
-import Navbar from '../components/Navbar';
-import Sidebar from '../components/Sidebar';
-import type { ReactNode } from 'react';
+import { CssBaseline, ThemeProvider, createTheme, Box } from '@mui/material';
+import { useMemo, useState, ReactNode } from 'react';
+import Navbar from '../components/layout/Navbar';
+import Sidebar, { drawerWidth } from '../components/layout/Sidebar';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
+  const [mode, setMode] = useState<'light' | 'dark'>('light');
+  const [collapsed, setCollapsed] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  const theme = useMemo(() => createTheme({ palette: { mode } }), [mode]);
+
+  const toggleColor = () => setMode((prev) => (prev === 'light' ? 'dark' : 'light'));
+  const toggleSidebar = () => {
+    if (typeof window !== 'undefined' && window.innerWidth < theme.breakpoints.values.md) {
+      setMobileOpen((prev) => !prev);
+    } else {
+      setCollapsed((prev) => !prev);
+    }
+  };
+
   return (
     <html lang="en">
-      <head />
       <body>
-        <CssBaseline />
-        <Navbar />
-        <div style={{ display: 'flex' }}>
-          <Sidebar />
-          <main style={{ flexGrow: 1 }}>{children}</main>
-        </div>
+        <ThemeProvider theme={theme}>
+          <CssBaseline />
+          <Box display="flex" minHeight="100vh">
+            <Navbar toggleSidebar={toggleSidebar} toggleColor={toggleColor} mode={mode} />
+            <Sidebar collapsed={collapsed} mobileOpen={mobileOpen} toggle={toggleSidebar} />
+            <Box component="main" flexGrow={1} pt={7} pl={drawerWidth}>
+              {children}
+            </Box>
+          </Box>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/app/sales/page.tsx
+++ b/app/sales/page.tsx
@@ -1,0 +1,3 @@
+export default function SalesPage() {
+  return <h1>Sales</h1>;
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,3 @@
+export default function SettingsPage() {
+  return <h1>Settings</h1>;
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,7 +1,0 @@
-export default function Navbar() {
-  return (
-    <nav style={{ padding: '1rem', background: '#eee' }}>
-      Navbar
-    </nav>
-  );
-}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,7 +1,0 @@
-export default function Sidebar() {
-  return (
-    <aside style={{ width: '200px', background: '#fafafa', padding: '1rem' }}>
-      Sidebar
-    </aside>
-  );
-}

--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -1,0 +1,32 @@
+'use client';
+import AppBar from '@mui/material/AppBar';
+import Toolbar from '@mui/material/Toolbar';
+import IconButton from '@mui/material/IconButton';
+import Typography from '@mui/material/Typography';
+import MenuIcon from '@mui/icons-material/Menu';
+import LightModeIcon from '@mui/icons-material/LightMode';
+import DarkModeIcon from '@mui/icons-material/DarkMode';
+
+interface NavbarProps {
+  toggleSidebar: () => void;
+  toggleColor: () => void;
+  mode: 'light' | 'dark';
+}
+
+export default function Navbar({ toggleSidebar, toggleColor, mode }: NavbarProps) {
+  return (
+    <AppBar position="fixed" elevation={0} sx={{ height: 56, justifyContent: 'center' }}>
+      <Toolbar>
+        <IconButton edge="start" color="inherit" onClick={toggleSidebar}>
+          <MenuIcon />
+        </IconButton>
+        <Typography variant="h6" sx={{ flexGrow: 1 }}>
+          Dashboard
+        </Typography>
+        <IconButton color="inherit" onClick={toggleColor}>
+          {mode === 'light' ? <LightModeIcon /> : <DarkModeIcon />}
+        </IconButton>
+      </Toolbar>
+    </AppBar>
+  );
+}

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -1,0 +1,88 @@
+'use client';
+import { Drawer, List, ListItemButton, ListItemIcon, ListItemText, useMediaQuery } from '@mui/material';
+import DashboardIcon from '@mui/icons-material/Dashboard';
+import BarChartIcon from '@mui/icons-material/BarChart';
+import SettingsIcon from '@mui/icons-material/Settings';
+import { useTheme } from '@mui/material/styles';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import type { ReactNode } from 'react';
+
+export const drawerWidth = 240;
+
+export interface NavItem {
+  title: string;
+  icon: ReactNode;
+  href: string;
+}
+
+export const navItems: NavItem[] = [
+  { title: 'Dashboard', icon: <DashboardIcon />, href: '/' },
+  { title: 'Sales', icon: <BarChartIcon />, href: '/sales' },
+  { title: 'Settings', icon: <SettingsIcon />, href: '/settings' },
+];
+
+interface SidebarProps {
+  collapsed: boolean;
+  mobileOpen: boolean;
+  toggle: () => void;
+}
+
+export default function Sidebar({ collapsed, mobileOpen, toggle }: SidebarProps) {
+  const pathname = usePathname();
+  const theme = useTheme();
+  const mdUp = useMediaQuery(theme.breakpoints.up('md'));
+
+  const content = (
+    <List sx={{ width: collapsed ? 72 : drawerWidth, transition: theme.transitions.create('width') }}>
+      {navItems.map((item) => (
+        <ListItemButton
+          key={item.href}
+          component={Link}
+          href={item.href}
+          selected={pathname === item.href}
+          sx={{ justifyContent: collapsed ? 'center' : 'flex-start' }}
+        >
+          <ListItemIcon sx={{ minWidth: 0, mr: collapsed ? 0 : 2 }}>
+            {item.icon}
+          </ListItemIcon>
+          {!collapsed && <ListItemText primary={item.title} />}
+        </ListItemButton>
+      ))}
+    </List>
+  );
+
+  if (mdUp) {
+    return (
+      <Drawer
+        variant="permanent"
+        open={!collapsed}
+        sx={{
+          width: collapsed ? 72 : drawerWidth,
+          flexShrink: 0,
+          '& .MuiDrawer-paper': {
+            width: collapsed ? 72 : drawerWidth,
+            boxSizing: 'border-box',
+            transition: theme.transitions.create('width'),
+          },
+        }}
+      >
+        {content}
+      </Drawer>
+    );
+  }
+
+  return (
+    <Drawer
+      variant="temporary"
+      open={mobileOpen}
+      onClose={toggle}
+      ModalProps={{ keepMounted: true }}
+      sx={{
+        '& .MuiDrawer-paper': { width: drawerWidth, boxSizing: 'border-box' },
+      }}
+    >
+      {content}
+    </Drawer>
+  );
+}


### PR DESCRIPTION
## Summary
- create `.gitignore`
- implement responsive MUI layout and theme toggle
- add Navbar and Sidebar components under `components/layout`
- stub pages for sales and settings

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find type definition files)*

------
https://chatgpt.com/codex/tasks/task_e_687cdb7420f4832f89de7378619035cc