### PR TITLE
Add client directive for KPI components

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,8 @@
 1. Ensure you are using **Node.js 20**.
 2. Run `npm install` to install dependencies.
 3. Start the development server with `npm run dev`.
+
+## Local Mock API
+
+During development the endpoint `/api/kpi` returns static KPI data used by the dashboard cards.
+

--- a/app/api/kpi/route.ts
+++ b/app/api/kpi/route.ts
@@ -1,0 +1,8 @@
+export async function GET() {
+  return Response.json({
+    revenue: 126400,
+    orders: 231,
+    traffic: 87500,
+    conversion: 2.14,
+  });
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,54 @@
+'use client';
+import Grid from '@mui/material/Grid';
+import { AttachMoney, ShoppingCart, BarChart, TrendingUp } from '@mui/icons-material';
+import KpiCard from '../components/kpi/KpiCard';
+import useKpi from '../hooks/useKpi';
+
 export default function HomePage() {
-  return <h1>Dashboard Home</h1>;
+  const { data } = useKpi();
+
+  return (
+    <Grid container spacing={2}>
+      {data && (
+        <>
+          <Grid item xs={12} md={3}>
+            <KpiCard
+              title="Revenue"
+              value={`$${data.revenue.toLocaleString()}`}
+              diff={5.2}
+              icon={<AttachMoney />}
+              color="primary"
+            />
+          </Grid>
+          <Grid item xs={12} md={3}>
+            <KpiCard
+              title="Orders"
+              value={data.orders}
+              diff={-1.3}
+              icon={<ShoppingCart />}
+              color="secondary"
+            />
+          </Grid>
+          <Grid item xs={12} md={3}>
+            <KpiCard
+              title="Traffic"
+              value={data.traffic}
+              diff={3.1}
+              icon={<BarChart />}
+              color="info"
+            />
+          </Grid>
+          <Grid item xs={12} md={3}>
+            <KpiCard
+              title="CVR"
+              value={`${data.conversion}%`}
+              diff={0.4}
+              icon={<TrendingUp />}
+              color="success"
+            />
+          </Grid>
+        </>
+      )}
+    </Grid>
+  );
 }

--- a/components/kpi/KpiCard.tsx
+++ b/components/kpi/KpiCard.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { Card, CardContent, Typography, Box } from '@mui/material';
+import { ArrowUpward, ArrowDownward } from '@mui/icons-material';
+import type { ReactElement } from 'react';
+
+interface KpiCardProps {
+  title: string;
+  value: React.ReactNode;
+  diff: number;
+  icon: ReactElement;
+  color?: 'primary' | 'secondary' | 'info' | 'success' | 'error' | 'warning' | string;
+}
+
+export default function KpiCard({ title, value, diff, icon, color }: KpiCardProps) {
+  const DiffIcon = diff >= 0 ? ArrowUpward : ArrowDownward;
+  const diffColor = diff >= 0 ? 'green' : 'red';
+
+  return (
+    <Card>
+      <CardContent>
+        <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
+          <Box color={color}>{icon}</Box>
+          <Box display="flex" alignItems="center" color={diffColor}>
+            <DiffIcon fontSize="small" />
+            <Typography variant="body2" ml={0.5}>{Math.abs(diff)}%</Typography>
+          </Box>
+        </Box>
+        <Typography variant="subtitle2" color="text.secondary">
+          {title}
+        </Typography>
+        <Typography variant="h6">{value}</Typography>
+      </CardContent>
+    </Card>
+  );
+}

--- a/hooks/useKpi.ts
+++ b/hooks/useKpi.ts
@@ -1,0 +1,9 @@
+'use client';
+
+import useSWR from 'swr';
+
+const fetcher = (url: string) => fetch(url).then(res => res.json());
+
+export default function useKpi() {
+  return useSWR('/api/kpi', fetcher);
+}


### PR DESCRIPTION
## Summary
- mark `KpiCard` and `useKpi` as client components so MUI elements render in the app router

## Testing
- `npm run lint` *(fails: `next` not found due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687cdce063d4832fa38e3289dda5851d